### PR TITLE
Feature: Add stan_fit unit tests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - master
+  schedule:
+    - cron: '5 4 * * 1'
   pull_request:
     branches:
       - main
@@ -33,7 +35,8 @@ jobs:
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       CMDSTAN_VERSION: "2.28.0"
-
+      NOT_CRAN: true
+      
     steps:
       - name: cmdstan env vars
         run: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -14,6 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       CMDSTAN_VERSION: "2.28.0"
+      NOT_CRAN: true
     steps:
       - name: cmdstan env vars
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: forecast.vocs
 Title: Forecast Case and Sequence Notifications using Variant of Concern
     Strain Dynamics
-Version: 0.0.5.3000
+Version: 0.0.5.4000
 Authors@R:
     person("Sam Abbott", , , "sam.abbott@lshtm.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8057-8037"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # forecast.vocs 0.0.6
-
+#
 * Add a vignette defining the package models.
 * Updated documentation to use `{preferably}`.
+* Add basic tests for all modelling functions.
 
 # forecast.vocs 0.0.5
 

--- a/R/model.R
+++ b/R/model.R
@@ -256,7 +256,8 @@ stan_fit <- function(data, model = forecast.vocs::load_model(strains = 2),
         fit$summary(
           variables = NULL, posterior::rhat,
           .args = list(na.rm = TRUE)
-        )$`posterior::rhat`
+        )$`posterior::rhat`,
+        na.rm = TRUE
       ),
       divergent_transitions = sum(diag$divergent__),
       per_divergent_transitons = sum(diag$divergent__) / nrow(diag),

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -33,7 +33,7 @@ test_stan_fit <- function(message, dt, model, inits) {
       )
     )
     expect_equal(class(fit$fit[[1]])[1], "CmdStanMCMC")
-    expect_lt(fit$per_divergent_transitons, 0.1)
+    expect_lt(fit$per_divergent_transitons, 0.15)
     expect_lt(fit$max_treedepth, 15)
     expect_lt(fit$max_rhat, 1.1)
     expect_type(fit$fit_args[[1]], "list")

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -1,0 +1,42 @@
+on_ci <- function() {
+  isTRUE(as.logical(Sys.getenv("CI")))
+}
+
+not_on_cran <- function() {
+  on_ci() || identical(Sys.getenv("NOT_CRAN"), "true")
+}
+
+silent_stan_fit <- function(...) {
+  utils::capture.output(
+    fit <- suppressMessages(stan_fit(...))
+  )
+  return(fit)
+}
+
+test_stan_fit <- function(message, dt, model, inits) {
+  test_that(message, {
+    skip_on_cran()
+    fit <- silent_stan_fit(
+      data = dt, model = model, init = inits, chains = 2, adapt_delta = 0.9,
+      max_treedepth = 15, refresh = 0, show_messages = FALSE,
+      iter_warmup = 1000, iter_sampling = 1000
+    )
+    expect_type(fit, "list")
+    expect_true(data.table::is.data.table(fit))
+    expect_equal(nrow(fit), 1)
+    expect_named(
+      fit,
+      expected = c(
+        "fit", "data", "fit_args", "samples", "max_rhat",
+        "divergent_transitions", "per_divergent_transitons", "max_treedepth",
+        "no_at_max_treedepth", "per_at_max_treedepth"
+      )
+    )
+    expect_equal(class(fit$fit[[1]])[1], "CmdStanMCMC")
+    expect_lt(fit$per_divergent_transitons, 0.1)
+    expect_lt(fit$max_treedepth, 15)
+    expect_lt(fit$max_rhat, 1.1)
+    expect_type(fit$fit_args[[1]], "list")
+    expect_type(fit$data[[1]], "list")
+  })
+}

--- a/tests/testthat/test-load_model.R
+++ b/tests/testthat/test-load_model.R
@@ -11,6 +11,7 @@ test_that("Returns paths to models", {
 test_that(
   "Compilation of the single strain models is successful and syntax is valid",
   { # nolint
+    skip_on_cran()
     single <- suppressMessages(load_model(strains = 1, compile = TRUE))
     single <- suppressMessages(cmdstanr::cmdstan_model(single))
     expect_error(suppressMessages(single$check_syntax()), NA)
@@ -20,6 +21,7 @@ test_that(
 test_that(
   "Compilation of two strain model is successful and syntax is valid",
   { # nolint
+    skip_on_cran()
     two <- suppressMessages(load_model(strains = 2, compile = TRUE))
     two <- suppressMessages(cmdstanr::cmdstan_model(two))
     expect_error(suppressMessages(two$check_syntax()), NA)

--- a/tests/testthat/test-stan_fit.R
+++ b/tests/testthat/test-stan_fit.R
@@ -1,0 +1,85 @@
+options(mc.cores = 2)
+
+if (not_on_cran()) {
+  obs <- filter_by_availability(
+    germany_covid19_delta_obs,
+    date = "2021-06-26"
+  )
+
+  overdisp_dt <- stan_data(
+    obs,
+    overdispersion = TRUE, variant_relationship = "pooled",
+    voc_scale = c(0.4, 0.2)
+  )
+  nooverdisp_dt <- stan_data(obs, overdispersion = FALSE)
+  scaled_dt <- stan_data(
+    obs,
+    overdispersion = TRUE, variant_relationship = "scaled",
+    voc_scale = c(0.4, 0.2)
+  )
+  independent_dt <- stan_data(
+    obs,
+    overdispersion = TRUE, variant_relationship = "independent",
+    voc_scale = c(0.4, 0.2)
+  )
+  ndisp_scaled_dt <- stan_data(
+    obs,
+    overdispersion = FALSE, variant_relationship = "scaled",
+    voc_scale = c(0.4, 0.2)
+  )
+  ndisp_independent_dt <- stan_data(
+    obs,
+    overdispersion = FALSE, variant_relationship = "independent",
+    voc_scale = c(0.4, 0.2)
+  )
+  inits1 <- stan_inits(overdisp_dt, strains = 1)
+  inits2 <- stan_inits(overdisp_dt, strains = 2)
+  one_model <- suppressMessages(load_model(strains = 1))
+  two_model <- suppressMessages(load_model(strains = 2))
+}
+
+test_stan_fit(
+  "The single strain model with overdispersion can be fit as expected",
+  overdisp_dt, one_model, inits1
+)
+
+test_stan_fit(
+  "The single strain model without overdispersion can be fit as expected",
+  nooverdisp_dt, one_model, inits1
+)
+
+test_stan_fit(
+  "The two strain model with pooling and overdispersion can be fit as
+   expected",
+  overdisp_dt, two_model, inits2
+)
+
+test_stan_fit(
+  "The two strain model with pooling and without overdispersion can be fit as
+   expected",
+  nooverdisp_dt, two_model, inits2
+)
+
+test_stan_fit(
+  "The two strain model with scaling and overdispersion can be fit as
+   expected",
+  scaled_dt, two_model, inits2
+)
+
+test_stan_fit(
+  "The two strain model with scaling and no overdispersion can be fit as
+   expected",
+  ndisp_scaled_dt, two_model, inits2
+)
+
+test_stan_fit(
+  "The two strain model with independence and overdispersion can be fit as
+   expected",
+  independent_dt, two_model, inits2
+)
+
+test_stan_fit(
+  "The two strain model with independence and no overdispersion can be fit as
+   expected",
+  ndisp_independent_dt, two_model, inits2
+)

--- a/tests/testthat/test-stan_fit.R
+++ b/tests/testthat/test-stan_fit.R
@@ -67,19 +67,7 @@ test_stan_fit(
 )
 
 test_stan_fit(
-  "The two strain model with scaling and no overdispersion can be fit as
-   expected",
-  ndisp_scaled_dt, two_model, inits2
-)
-
-test_stan_fit(
   "The two strain model with independence and overdispersion can be fit as
    expected",
   independent_dt, two_model, inits2
-)
-
-test_stan_fit(
-  "The two strain model with independence and no overdispersion can be fit as
-   expected",
-  ndisp_independent_dt, two_model, inits2
 )


### PR DESCRIPTION
This PR adds unit tests for `stan_fit`. These tests check the output from `stan_fit` for each strain model with a range of options. Convergence diagnostics are also assessed. A downside of this approach is that unit tests now take approximately 5 minutes to run  to completion. 

This PR also: 

* Adds a weekly CRON check
* Drops NA Rhat from the `stan_fit` output. This may occur spuriously when a parameter is excluded from the model (i.e overdispersion).