### PR TITLE
Bug: #95 Make generate_obs support all strain models

### DIFF
--- a/R/generate-data.R
+++ b/R/generate-data.R
@@ -47,7 +47,9 @@ sample_sequences <- function(frac_voc, seq_total, phi) {
 #' Generate Simulated Observations
 #'
 #' Generate simulated observations from the prior or posterior
-#' distributions of a `forecast.vocs` model.
+#' distributions of a `forecast.vocs` model. When a single strain model is used
+#' only case data is simulated but when a multiple strain model is used sequence
+#' data is also simulated.
 #'
 #' @param obs Observed data to use to parameterise the model and used for
 #' fitting when the posterior is required.

--- a/man/generate_obs.Rd
+++ b/man/generate_obs.Rd
@@ -56,7 +56,7 @@ obs <- latest_obs(germany_covid19_delta_obs)
 sim_obs <- generate_obs(obs, voc_scale = c(0.8, 0.1), r_init = c(-0.1, 0.05))
 
 # fit a simulated dataset
-sim_dt <- sim_obs$fv_as_data_list[[1]]
+sim_dt <- sim_obs$data[[1]]
 inits <- fv_inits(sim_dt)
 fit <- fv_sample(
   sim_dt,

--- a/man/generate_obs.Rd
+++ b/man/generate_obs.Rd
@@ -46,7 +46,9 @@ with the same arguments as specified  for simulation).
 }
 \description{
 Generate simulated observations from the prior or posterior
-distributions of a \code{forecast.vocs} model.
+distributions of a \code{forecast.vocs} model. When a single strain model is used
+only case data is simulated but when a multiple strain model is used sequence
+data is also simulated.
 }
 \examples{
 \dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/tests/testthat/test-generate_obs.R
+++ b/tests/testthat/test-generate_obs.R
@@ -1,0 +1,38 @@
+
+test_that("Two strain model can be used to generate observations", {
+  skip_on_cran()
+  f <- utils::capture.output(
+    sim_obs <- suppressMessages(
+      generate_obs(obs, strains = 2)
+    )
+  )
+  expect_named(
+    sim_obs,
+    c("dataset", "parameters", "obs", "data")
+  )
+  expect_error(check_observations(sim_obs$obs[[1]]), NA)
+  expect_error(fv_inits(sim_obs$data[[1]], strains = 2), NA)
+  expect_named(
+    sim_obs$parameters[[1]],
+    c(".draw", ".iteration", ".chain", "parameter", "sample")
+  )
+})
+
+test_that("Single strain model can be used to generate observations", {
+  skip_on_cran()
+  f <- utils::capture.output(
+    sim_obs <- suppressMessages(
+      generate_obs(obs, strains = 1)
+    )
+  )
+  expect_named(
+    sim_obs,
+    c("dataset", "parameters", "obs", "data")
+  )
+  expect_error(check_observations(sim_obs$obs[[1]]), NA)
+  expect_error(fv_inits(sim_obs$data[[1]], strains = 1), NA)
+  expect_named(
+    sim_obs$parameters[[1]],
+    c(".draw", ".iteration", ".chain", "parameter", "sample")
+  )
+})

--- a/tests/testthat/test-sample_sequences.R
+++ b/tests/testthat/test-sample_sequences.R
@@ -1,0 +1,18 @@
+
+# Make test data
+frac_voc <- seq(0, 1, by = 0.1)
+seq_total <- seq(10, length.out = length(frac_voc), by = 100)
+
+test_that("Binomial observation model can be sampled from as expected", {
+  seq <- sample_sequences(frac_voc, seq_total)
+  expect_type(seq, "double")
+  expect_equal(length(seq), 11)
+  expect_true(!any(is.na(seq)))
+})
+
+test_that("Beta binomial observation model can be sampled from as expected", {
+  seq <- sample_sequences(frac_voc, seq_total, 0.1)
+  expect_type(seq, "double")
+  expect_equal(length(seq), 11)
+  expect_true(!any(is.na(seq)))
+})


### PR DESCRIPTION
This PR makes generate_obs support all strain models as well as adding tests for this and default functionality.